### PR TITLE
Add Elasticsearch exporter

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,3 @@
+mod elasticsearch;
+
+pub use elasticsearch::ElasticsearchBuilder;

--- a/src/client/elasticsearch.rs
+++ b/src/client/elasticsearch.rs
@@ -1,0 +1,50 @@
+use color_eyre::eyre::Result;
+use elasticsearch::{
+    self,
+    cert::CertificateValidation,
+    http::{
+        self,
+        transport::{SingleNodeConnectionPool, TransportBuilder},
+    },
+};
+use url::Url;
+
+pub struct ElasticsearchBuilder {
+    cert_validation: CertificateValidation,
+    connection_pool: SingleNodeConnectionPool,
+    headers: http::headers::HeaderMap,
+    url: Url,
+}
+
+impl ElasticsearchBuilder {
+    pub fn new(url: Url) -> Self {
+        let mut headers = http::headers::HeaderMap::new();
+        headers.append(http::headers::ACCEPT_ENCODING, "gzip".parse().unwrap());
+
+        Self {
+            cert_validation: CertificateValidation::Default,
+            connection_pool: SingleNodeConnectionPool::new(url.clone()),
+            headers,
+            url,
+        }
+    }
+
+    pub fn insecure(self, ignore_certs: bool) -> Self {
+        let cert_validation = match ignore_certs {
+            true => CertificateValidation::None,
+            false => CertificateValidation::Default,
+        };
+        Self {
+            cert_validation,
+            ..self
+        }
+    }
+
+    pub fn build(self) -> Result<elasticsearch::Elasticsearch> {
+        let transport = TransportBuilder::new(self.connection_pool)
+            .headers(self.headers)
+            .cert_validation(self.cert_validation)
+            .build()?;
+        Ok(elasticsearch::Elasticsearch::new(transport))
+    }
+}

--- a/src/data/shards.rs
+++ b/src/data/shards.rs
@@ -104,4 +104,8 @@ impl ShardDoc {
             stats,
         }
     }
+
+    pub fn as_value(&self) -> serde_json::Value {
+        serde_json::to_value(self).expect("Failed to serialize ShardDoc")
+    }
 }

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -1,38 +1,55 @@
+mod elasticsearch;
 mod file;
 mod stream;
 
 use crate::data::ShardDoc;
 use color_eyre::eyre::Result;
+use elasticsearch::ElasticsearchExporter;
 use file::FileExporter;
 use std::path::Path;
 use stream::StreamExporter;
+use url::Url;
 
 trait Export {
-    fn write(&self, docs: Vec<ShardDoc>) -> Result<()>;
-    fn is_connected(&self) -> bool;
+    async fn write(&self, docs: Vec<ShardDoc>) -> Result<()>;
+    async fn is_connected(&self) -> bool;
 }
 
 pub enum Exporter {
+    Elasticsearch(ElasticsearchExporter),
     File(FileExporter),
     Stream(StreamExporter),
 }
 
 impl Exporter {
     pub fn parse(output: Option<&String>) -> Result<Self> {
-        match output {
-            None => Ok(Self::Stream(StreamExporter::new())),
-            Some(output) => {
-                let path = Path::new(output);
-                let file_exporter = FileExporter::new(path.to_path_buf())?;
-                Ok(Self::File(file_exporter))
+        // No output given, write to stdout
+        let output = match output {
+            None => {
+                let exporter = StreamExporter::new();
+                return Ok(Self::Stream(exporter));
             }
-        }
+            Some(output) => output,
+        };
+        // Attempt to parse the output as a URL
+        match Url::parse(output) {
+            Ok(url) => {
+                let exporter = ElasticsearchExporter::new(url)?;
+                return Ok(Self::Elasticsearch(exporter));
+            }
+            Err(_) => log::debug!("Output was not a valid URL"),
+        };
+        // Fallback to a file path
+        let path = Path::new(output);
+        let exporter = FileExporter::new(path.to_path_buf())?;
+        Ok(Self::File(exporter))
     }
 
-    pub fn write(&self, docs: Vec<ShardDoc>) -> Result<()> {
+    pub async fn write(&self, docs: Vec<ShardDoc>) -> Result<()> {
         match self {
-            Self::File(exporter) => exporter.write(docs),
-            Self::Stream(exporter) => exporter.write(docs),
+            Self::Elasticsearch(exporter) => exporter.write(docs).await,
+            Self::File(exporter) => exporter.write(docs).await,
+            Self::Stream(exporter) => exporter.write(docs).await,
         }
     }
 }
@@ -40,6 +57,7 @@ impl Exporter {
 impl std::fmt::Display for Exporter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Elasticsearch(exporter) => write!(f, "elasticsearch {}", exporter),
             Self::File(exporter) => write!(f, "file {}", exporter),
             Self::Stream(exporter) => write!(f, "stream {}", exporter),
         }

--- a/src/exporter/elasticsearch.rs
+++ b/src/exporter/elasticsearch.rs
@@ -1,0 +1,49 @@
+use super::Export;
+use crate::client::ElasticsearchBuilder;
+use crate::data::ShardDoc;
+use color_eyre::eyre::Result;
+use elasticsearch::{BulkOperation, BulkParts, Elasticsearch};
+use url::Url;
+
+pub struct ElasticsearchExporter {
+    client: Elasticsearch,
+    url: Url,
+}
+
+impl ElasticsearchExporter {
+    pub fn new(url: Url) -> Result<Self> {
+        let client = ElasticsearchBuilder::new(url.clone())
+            .insecure(true)
+            .build()?;
+
+        Ok(Self { client, url })
+    }
+}
+
+impl Export for ElasticsearchExporter {
+    async fn write(&self, docs: Vec<ShardDoc>) -> Result<()> {
+        let index = "eshipster-shards";
+        let ops: Vec<BulkOperation<serde_json::Value>> = docs
+            .into_iter()
+            .map(|doc| BulkOperation::create(doc.as_value()).into())
+            .collect();
+
+        self.client
+            .bulk(BulkParts::Index(&index))
+            .body(ops)
+            .send()
+            .await?;
+
+        Ok(())
+    }
+
+    async fn is_connected(&self) -> bool {
+        true
+    }
+}
+
+impl std::fmt::Display for ElasticsearchExporter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.url)
+    }
+}

--- a/src/exporter/file.rs
+++ b/src/exporter/file.rs
@@ -14,20 +14,24 @@ pub struct FileExporter {
 
 impl FileExporter {
     pub fn new(path: PathBuf) -> Result<Self> {
-        let file = OpenOptions::new().write(true).create(true).open(&path)?;
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&path)?;
         Ok(Self { file, path })
     }
 }
 
 impl Export for FileExporter {
-    fn is_connected(&self) -> bool {
+    async fn is_connected(&self) -> bool {
         let is_file = self.path.is_file();
         let filename = self.path.to_str().unwrap_or("");
         log::debug!("File {filename} is valid: {is_file}");
         is_file
     }
 
-    fn write(&self, docs: Vec<ShardDoc>) -> Result<()> {
+    async fn write(&self, docs: Vec<ShardDoc>) -> Result<()> {
         log::info!(
             "Writing {} docs to file {}",
             docs.len(),

--- a/src/exporter/stream.rs
+++ b/src/exporter/stream.rs
@@ -11,7 +11,7 @@ impl StreamExporter {
 }
 
 impl Export for StreamExporter {
-    fn write(&self, docs: Vec<ShardDoc>) -> Result<()> {
+    async fn write(&self, docs: Vec<ShardDoc>) -> Result<()> {
         log::debug!("Writing {} docs to stdout", docs.len());
         for doc in docs {
             serde_json::to_writer(std::io::stdout(), &doc)?;
@@ -20,7 +20,7 @@ impl Export for StreamExporter {
         Ok(())
     }
 
-    fn is_connected(&self) -> bool {
+    async fn is_connected(&self) -> bool {
         true
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod client;
 mod data;
 mod env;
 mod exporter;
@@ -88,7 +89,7 @@ async fn main() {
                 .await
                 .expect("Failed to evaluate shard balance");
             log::info!("Writing docs to {exporter}");
-            exporter.write(docs).expect("Failed to write docs");
+            exporter.write(docs).await.expect("Failed to write docs");
         }
         Commands::Setup { host } => {
             log::info!("Setting up eshipster datastreams on {host}");


### PR DESCRIPTION
Adds an exporter for Elasticsearch that writes JSON documents to the `_bulk` API.

Refactors the logic to build an Elasticsearch client into an `ElasticsearchBuilder` that can be shared between the receiver and exporter.

Fixes a minor bug to truncate output file on write. This was allowing old data to hang around if the new data was shorter than the existing contents.